### PR TITLE
watcher saga fixes

### DIFF
--- a/src/store/app/app.slice.ts
+++ b/src/store/app/app.slice.ts
@@ -30,6 +30,8 @@ export const appSlice = createSlice({
       state.currentBlockNumber = undefined;
       state.provider = undefined;
       state.connectedWallet = undefined;
+      state.chainId = undefined;
+      state.account = undefined;
     },
     setBlockNumber: (state, { payload }: PayloadAction<number>) => {
       state.currentBlockNumber = payload;

--- a/src/store/app/app.updaters.ts
+++ b/src/store/app/app.updaters.ts
@@ -15,23 +15,27 @@ export const AppUpdater = () => {
 
   useEffect(() => {
     const name = getWalletName(connector);
-    dispatch(appActions.setConnectedWallet(name));
+    if (name) {
+      dispatch(appActions.setConnectedWallet(name));
+    }
   }, [connector, dispatch]);
 
   useEffect(() => {
-    dispatch(appActions.setChainId(chainId));
+    if (chainId) {
+      dispatch(appActions.setChainId(chainId));
+    }
   }, [chainId, dispatch]);
 
   useEffect(() => {
-    dispatch(appActions.setAccount(account));
+    if (account) {
+      dispatch(appActions.setAccount(account));
+    }
   }, [account, dispatch]);
 
   useEffect(() => {
-    if (!library) {
-      dispatch(appActions.walletDisconnected());
-      return;
+    if (library) {
+      dispatch(appActions.walletConnected(library));
     }
-    dispatch(appActions.walletConnected(library));
   }, [library, chainId, dispatch]);
 
   return null;

--- a/src/store/dashboard/dashboard.slice.ts
+++ b/src/store/dashboard/dashboard.slice.ts
@@ -9,7 +9,9 @@ export const dashboardSlice = createSlice({
   name: Reducers.Dashboard,
   initialState,
   reducers: {
-    watchData: (_) => {},
+    watchData: (state) => {
+      state.balances.state = 'loading';
+    },
     stopWatchingData: (state) => {
       state.balances.state = 'idle';
     },

--- a/src/store/proposals/proposals.slice.ts
+++ b/src/store/proposals/proposals.slice.ts
@@ -16,7 +16,9 @@ export const proposalSlice = createSlice({
   name: Reducers.Proposals,
   initialState,
   reducers: {
-    watchProposalsList: () => {},
+    watchProposalsList: (state) => {
+      state.proposalsList.state = 'loading';
+    },
     stopWatchingProposalsList: (state) => {
       state.proposalsList.state = 'idle';
     },

--- a/src/store/staking/staking.slice.ts
+++ b/src/store/staking/staking.slice.ts
@@ -59,7 +59,12 @@ export const stakingSlice = createSlice({
     setExtendStepData: extendStakeStepCallActions.updateStep,
     setExtendError: extendStakeStepCallActions.setStepError,
 
-    watchStakingData: (_) => {},
+    watchStakingData: (state) => {
+      state.fishToken.state = 'loading';
+      state.combinedVotingPower.state = 'loading';
+      state.stakesList.state = 'loading';
+      state.stakesListHistory.state = 'loading';
+    },
     stopWatchingStakingData: (state) => {
       state.fishToken.state = 'idle';
       state.combinedVotingPower.state = 'idle';
@@ -68,11 +73,14 @@ export const stakingSlice = createSlice({
     },
     fetchStakingData: (state) => {
       state.constants.state = 'loading';
-
-      state.fishToken = initialState.fishToken;
-      state.stakesList = initialState.stakesList;
-      state.stakesListHistory = initialState.stakesListHistory;
-      state.combinedVotingPower = initialState.combinedVotingPower;
+      state.fishToken.state = 'loading';
+      state.combinedVotingPower.state = 'loading';
+      state.stakesList.state = 'loading';
+      state.stakesListHistory.state = 'loading';
+      state.fishToken.data = {};
+      state.combinedVotingPower.data = undefined;
+      state.stakesList.data = [];
+      state.stakesListHistory.data = [];
     },
     updateStakingData: (state) => {
       state.fishToken.state = 'loading';

--- a/src/store/utils/utils.sagas.test.ts
+++ b/src/store/utils/utils.sagas.test.ts
@@ -109,7 +109,7 @@ describe('saga utils', () => {
     });
 
     it('should make an initial fetch call when watching is started and address is set', () => {
-      store.dispatch(appActions.setAccount('account'));
+      store.dispatch(appActions.walletConnected(mockProvider));
       store.dispatch(mockActions.watch());
 
       expect(mockFetch).toHaveBeenCalled();
@@ -119,13 +119,14 @@ describe('saga utils', () => {
     describe('watching', () => {
       beforeEach(() => {
         store.dispatch(mockActions.watch());
+        store.dispatch(appActions.walletConnected(mockProvider));
 
         mockFetch.mockClear();
       });
 
       it('should update on account and blockNumber change', () => {
-        store.dispatch(appActions.setAccount());
         store.dispatch(appActions.setBlockNumber(31));
+        store.dispatch(appActions.setAccount('test account'));
 
         expect(mockFetch).not.toHaveBeenCalled();
         expect(mockUpdate).toHaveBeenCalledTimes(2);
@@ -135,6 +136,16 @@ describe('saga utils', () => {
         store.dispatch(appActions.walletConnected(mockProvider));
 
         expect(mockFetch).toHaveBeenCalled();
+        expect(mockUpdate).not.toHaveBeenCalled();
+      });
+
+      it('should not trigger updates when provider is not settled', () => {
+        store.dispatch(appActions.walletDisconnected());
+
+        store.dispatch(appActions.setBlockNumber(31));
+        store.dispatch(appActions.setAccount('test account'));
+
+        expect(mockFetch).not.toHaveBeenCalled();
         expect(mockUpdate).not.toHaveBeenCalled();
       });
 

--- a/src/store/vesting/vesting.mock.ts
+++ b/src/store/vesting/vesting.mock.ts
@@ -1,8 +1,7 @@
 import { BigNumber } from 'ethers';
 import { Vesting__factory } from '../../contracts/types/factories/Vesting__factory';
 import { createMockedContract, mockSigner } from '../../testUtils';
-import { LoadableValue } from '../types';
-import { VestListItem } from './vesting.state';
+import { VestingState, VestListItem } from './vesting.state';
 
 export const vestingAddress = '0x94e907f6B903A393E14FE549113137CA6483b5ef';
 export const accountAddress = '0x012A3';
@@ -38,18 +37,18 @@ export const combinedVestsList: VestListItem[] = [
 export const createMockVestingContract = (address: string) =>
   createMockedContract(Vesting__factory.connect(address, mockSigner), true);
 
-export const successVestingState = {
-  selectedVest: combinedVestsList[0].unlockDate,
+export const successVestingState: VestingState = {
+  selectedVest: combinedVestsList[0],
   vestsList: {
     state: 'success',
     data: combinedVestsList,
-  } as LoadableValue<VestListItem[]>,
+  },
 };
 
-export const failureVestingState = {
+export const failureVestingState: VestingState = {
   selectedVest: undefined,
   vestsList: {
     state: 'failure',
     data: [],
-  } as LoadableValue<VestListItem[]>,
+  },
 };

--- a/src/store/vesting/vesting.selectors.ts
+++ b/src/store/vesting/vesting.selectors.ts
@@ -16,12 +16,7 @@ export const vestsListStatusSelector = createSelector(
 );
 export const selectedVestSelector = createSelector(
   [vestingState, vestsListSelector],
-  (state, vestsList) => {
-    const selectedVest = vestsList.find(
-      (vest) => vest.unlockDate === state.selectedVest
-    );
-    return selectedVest;
-  }
+  (state) => state.selectedVest
 );
 
 export const selectedVestContractSelector = createSelector(

--- a/src/store/vesting/vesting.slice.ts
+++ b/src/store/vesting/vesting.slice.ts
@@ -9,7 +9,9 @@ export const vestingSlice = createSlice({
   name: Reducers.Vesting,
   initialState,
   reducers: {
-    watchVestingData: (_) => {},
+    watchVestingData: (state) => {
+      state.vestsList.state = 'loading';
+    },
     stopWatchingVestingData: (state) => {
       state.vestsList.state = 'idle';
     },
@@ -32,7 +34,10 @@ export const vestingSlice = createSlice({
     },
 
     selectVest: (state, { payload }: PayloadAction<number>) => {
-      state.selectedVest = payload;
+      const selectedVest = state.vestsList.data.find(
+        (vest) => vest.unlockDate === payload
+      );
+      state.selectedVest = selectedVest;
     },
     clearSelectedVest: (state) => {
       state.selectedVest = undefined;

--- a/src/store/vesting/vesting.state.ts
+++ b/src/store/vesting/vesting.state.ts
@@ -14,7 +14,7 @@ export type VestListAddress = {
 };
 
 export class VestingState {
-  selectedVest?: number;
+  selectedVest?: VestListItem;
 
   vestsList: LoadableValue<VestListItem[]> = {
     data: [],


### PR DESCRIPTION
watcher saga fixes

- fix triggering sagas before provider is settled
- fix transitory showing empty data before loading state
- store all vest data in the store to avoid bugs related to refetching data once the dialog window is opened